### PR TITLE
Can't use file plugin with disk string

### DIFF
--- a/src/File/Command/GetFile.php
+++ b/src/File/Command/GetFile.php
@@ -48,7 +48,12 @@ class GetFile
 
         if (!is_numeric($this->identifier)) {
 
-            list($folder, $name) = explode('/', $this->identifier);
+            /**
+             * The expected format is disk://folder/filename.extension
+             * We can ignore the first since it is the disk.
+             * We can ignore the second since it is always blank (//)
+             */
+            list(, , $folder, $name) = explode('/', $this->identifier);
 
             if (!$folder = $folders->findBySlug($folder)) {
                 return null;


### PR DESCRIPTION
file('local://documents/VS Company Brochure.pdf') return null, but file(131) returns the correct file.

This allows the disk string to be used with files.

Fixes https://github.com/pyrocms/pyrocms/issues/3863
