### PR TITLE
Uploading a file with html entities in the name.

### DIFF
--- a/src/File/FileUploader.php
+++ b/src/File/FileUploader.php
@@ -104,7 +104,7 @@ class FileUploader
 
         /* @var FileInterface|EloquentModel $entry */
         $entry = $this->manager->put(
-            $disk->getSlug() . '://' . $folder->getSlug() . '/' . $file->getClientOriginalName(),
+            $disk->getSlug() . '://' . $folder->getSlug() . '/' . urldecode($file->getClientOriginalName()),
             file_get_contents($file->getRealPath())
         );
 


### PR DESCRIPTION
There is an error if a user uploads a file with a name that contains a + or any other html entity code in it like %20. The file then returns a 404 since it is looking for the string %20, but the url interprets it as a space. Users be cray!