### PR TITLE
File exists check 404 fix

### DIFF
--- a/resources/js/upload.js
+++ b/resources/js/upload.js
@@ -23,7 +23,7 @@ $(function () {
                 formData.append('folder', element.data('folder'));
             },
             accept: function(file, done) {
-                $.getJSON(REQUEST_ROOT_PATH + '/admin/files/exists/' + element.data('folder') + '/' + file.name, function(data) {
+                $.getJSON(REQUEST_ROOT_PATH + '/admin/files/exists/' + element.data('folder') + '/' + file.name + '/check', function(data) {
                     if(data.exists) {
                         if(!confirm(file.name + " " + element.data('overwrite'))) {
                             dropzone.removeFile(file);

--- a/src/FilesModuleServiceProvider.php
+++ b/src/FilesModuleServiceProvider.php
@@ -76,7 +76,7 @@ class FilesModuleServiceProvider extends AddonServiceProvider
         'admin/files/upload/{folder}'                                  => 'Anomaly\FilesModule\Http\Controller\Admin\UploadController@index',
         'admin/files/edit/{id}'                                        => 'Anomaly\FilesModule\Http\Controller\Admin\FilesController@edit',
         'admin/files/view/{id}'                                        => 'Anomaly\FilesModule\Http\Controller\Admin\FilesController@view',
-        'admin/files/exists/{folder}/{name}'                           => 'Anomaly\FilesModule\Http\Controller\Admin\FilesController@exists',
+        'admin/files/exists/{folder}/{name}/check'                     => 'Anomaly\FilesModule\Http\Controller\Admin\FilesController@exists',
         'admin/files/folders'                                          => 'Anomaly\FilesModule\Http\Controller\Admin\FoldersController@index',
         'admin/files/folders/create'                                   => 'Anomaly\FilesModule\Http\Controller\Admin\FoldersController@create',
         'admin/files/folders/edit/{id}'                                => 'Anomaly\FilesModule\Http\Controller\Admin\FoldersController@edit',


### PR DESCRIPTION
Piterden from Slack couldn't replicate this issue, but on some web servers (tested on my local machine & cloud server with Nginx and on Google's Appengine) the route for checking if a file exists returns the data, but it returns with a status code of 404 which breaks file uploading.

This only happens if a server has a similar block to this with the extension of the file being uploaded.
```Nginx
location ~* ^.+\.(jpeg|jpg|png|gif|bmp|ico|svg|css|js)$ {
      expires     max;
      add_header  Pragma public;
      add_header  Cache-Control "public, must-revalidate, proxy-revalidate";
    }
```

I assume some configurations of Nginx think the file check route `http://newhamflames-new.dev/admin/files/exists/13/screenshot.png` is a file and returns a 404 because a file in that directory doesn't exist.