### PR TITLE
Properly set file size when uploading replacement file

### DIFF
--- a/src/File/FileSynchronizer.php
+++ b/src/File/FileSynchronizer.php
@@ -68,6 +68,7 @@ class FileSynchronizer
                 ]
             );
         } else {
+            $file->size = $resource->getSize();
 
             if ($file->trashed()) {
                 $this->files->restore($file);


### PR DESCRIPTION
Bug Fix: When replacement files are uploaded the size should be reset to match the new upload.