### PR TITLE
Remove superglobal references

### DIFF
--- a/src/File/FileStreamer.php
+++ b/src/File/FileStreamer.php
@@ -77,11 +77,11 @@ class FileStreamer extends FileResponse
         $response->headers->set('Content-length', $size);
         $response->headers->set('Content-Range', "bytes 0-{$end}/{$size}");
 
-        if (!$range = array_get($_SERVER, 'HTTP_RANGE')) {
+        if (!$range = app('request')->server->get('HTTP_RANGE')) {
             return;
         }
 
-        list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);
+        list(, $range) = explode('=', app('request')->server->get('HTTP_RANGE'), 2);
 
         if (strpos($range, ',') !== false) {
             $response->setStatusCode(416, 'Requested Range Not Satisfiable');

--- a/src/Http/Controller/Admin/DisksController.php
+++ b/src/Http/Controller/Admin/DisksController.php
@@ -7,6 +7,7 @@ use Anomaly\FilesModule\Disk\Form\DiskFormBuilder;
 use Anomaly\FilesModule\Disk\Table\DiskTableBuilder;
 use Anomaly\Streams\Platform\Addon\Extension\ExtensionCollection;
 use Anomaly\Streams\Platform\Http\Controller\AdminController;
+use Illuminate\Http\Request;
 
 /**
  * Class DisksController
@@ -61,7 +62,7 @@ class DisksController extends AdminController
         ExtensionCollection $adapters,
         ConfigurationFormBuilder $configuration
     ) {
-        $adapter = $adapter = $adapters->get($_GET['adapter']);
+        $adapter = $adapter = $adapters->get($requst->input('adapter'));
 
         $form->addForm('disk', $disk->setAdapter($adapter));
         $form->addForm('configuration', $configuration->setEntry($adapter->getNamespace()));


### PR DESCRIPTION
This PR replaces references to PHP superglobals ($_SERVER, $_REQUEST, $_GET, $_POST) with methods that act on the \Illuminate\Http\Request class.

Issue reference: pyrocms/pyrocms#4776.