### PR TITLE
Add quotes for filename in "Content-Disposition" header

### DIFF
--- a/src/File/FileDownloader.php
+++ b/src/File/FileDownloader.php
@@ -36,7 +36,7 @@ class FileDownloader extends FileResponse
     {
         $response = parent::make($file);
 
-        $response->headers->set('Content-disposition', 'attachment; filename=' . $file->getName());
+        $response->headers->set('Content-disposition', 'attachment; filename="' . $file->getName() . '""');
 
         $folder = $file->getFolder();
         $disk   = $folder->getDisk();


### PR DESCRIPTION
Filename in "Content-Disposition" header needs quotes because file name can contain spaces and special chars.