### PR TITLE
Install/Uninstall Migration Errors

### DIFF
--- a/src/File/FileModel.php
+++ b/src/File/FileModel.php
@@ -14,6 +14,7 @@ use Anomaly\Streams\Platform\Model\Files\FilesFilesEntryModel;
 use League\Flysystem\File;
 use League\Flysystem\FilesystemInterface;
 use League\Flysystem\MountManager;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class FileModel
@@ -24,7 +25,12 @@ use League\Flysystem\MountManager;
  */
 class FileModel extends FilesFilesEntryModel implements FileInterface
 {
-
+    /**
+     * Give accessed to method
+     * ->withTrashed()
+     **/
+    use SoftDeletes;
+    
     /**
      * This model is versionable.
      *

--- a/src/Folder/FolderModel.php
+++ b/src/Folder/FolderModel.php
@@ -7,6 +7,7 @@ use Anomaly\FilesModule\Folder\Contract\FolderInterface;
 use Anomaly\Streams\Platform\Model\Files\FilesFoldersEntryModel;
 use Anomaly\Streams\Platform\Stream\Contract\StreamInterface;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class FolderModel
@@ -18,6 +19,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class FolderModel extends FilesFoldersEntryModel implements FolderInterface
 {
 
+    /**
+     * Give accessed to method
+     * ->withTrashed()
+     **/
+    use SoftDeletes;
+    
     /**
      * Always eager load these.
      *


### PR DESCRIPTION
Also mentioned in pyrocms/pyrocms#5112.

**Describe the bug**
I'm unable to uninstall the files module with artisan.

**To Reproduce**
```
php artisan addon:uninstall anomaly.module.files
In 2016_10_05_221741_anomaly.module.files__make_disks_sortable.php line 25:

  Call to a member function setAttribute() on null
```

```
php artisan migrate --addon=anomaly.module.files
Migrating: 2019_08_02_010559_anomaly.module.files__add_str_id_to_files

In ForwardsCalls.php line 50:

  Call to undefined method Anomaly\FilesModule\File\FileModel::withTrashed()
```

This is using `"anomaly/files-module": "~2.6.0"` in my `composer.json`
